### PR TITLE
Explicity run in py2, adding support for IPv6

### DIFF
--- a/check_openvpn
+++ b/check_openvpn
@@ -1,10 +1,11 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 
-# Check if an OpenVPN server runs on a given UDP port.
+# Check if an OpenVPN server runs on a given UDP or TCP port.
 #
 # Copyright 2013 Roland Wolters
+# Copyright 2016 Alarig Le Lay
 #
-# Version 20151106
+# Version 20160803
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -74,13 +75,21 @@ def buildpacket(tcp, key, digestmod):
 
 def checkserver(host, port, tcp, timeout, key, digest):
     packet = buildpacket(tcp, key, digest)
-    if tcp: checkserver_tcp(host, port, timeout, packet)
-    else: checkserver_udp(host, port, timeout, packet)
+    if tcp:
+        checkserver_tcp(host, port, timeout, packet)
+    else:
+        checkserver_udp(host, port, timeout, packet)
 
 def checkserver_udp(host, port, timeout, packet):
-    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.settimeout(timeout)
-    
+    # thanks to glucas for the idea
+    try:
+        af, socktype, proto, canonname, sa = socket.getaddrinfo(host, port, \
+            socket.AF_UNSPEC, socket.SOCK_DGRAM)[0]
+        s = socket.socket(af, socktype, proto)
+        s.settimeout(timeout)
+    except socket.error:
+        return critical('Unable to create UDP socket')
+
     try:
         s.sendto(packet, (host, port))
         data, _ = s.recvfrom(BUFFER_SIZE)
@@ -92,9 +101,14 @@ def checkserver_udp(host, port, timeout, packet):
         s.close()
 
 def checkserver_tcp(host, port, timeout, packet):
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.settimeout(timeout)
-    
+    try:
+        af, socktype, proto, canonname, sa = socket.getaddrinfo(host, port, \
+            socket.AF_UNSPEC, socket.SOCK_STREAM)[0]
+        s = socket.socket(af, socktype, proto)
+        s.settimeout(timeout)
+    except socket.error:
+        return critical('Unable to create TCP socket')
+
     try:
         s.connect((host, port))
         s.send(packet)
@@ -123,10 +137,10 @@ def readkey(path):
 
 def optionsparser(args=None):
     parser = argparse.ArgumentParser()
-    parser.add_argument('-p', '--port', help='set port number (default is %%default)', type=int, dest='port', default='1194')
+    parser.add_argument('-p', '--port', help='set port number (default is 1194)', type=int, dest='port', default='1194')
     parser.add_argument('-t', '--tcp', help='use tcp instead of udp', action='store_true')
-    parser.add_argument('--timeout', help='set timeout (default is %%default)', type=int, default='5')
-    parser.add_argument('--digest', help='set HMAC digest (default is %%default)', type=str, default='sha1')
+    parser.add_argument('--timeout', help='set timeout (default is 5)', type=int, default='5')
+    parser.add_argument('--digest', help='set HMAC digest (default is sha1)', type=str, default='sha1')
     parser.add_argument('--digest-size', help='set HMAC digest size', type=int)
     parser.add_argument('--digest-key', help='set HMAC key', type=str, default=None)
     parser.add_argument('--tls-auth', help='set tls-auth file', type=str, default=None)


### PR DESCRIPTION
Hi,

I wanted to monitor an OpenVPN server over IPv6, so I added the IPv6 support.
I also modified the shebang because some distributions default to python3 when running python.